### PR TITLE
Fixes listing invoices documentation

### DIFF
--- a/source/includes/credit-notes.md
+++ b/source/includes/credit-notes.md
@@ -774,7 +774,7 @@ Reemplaza en la ruta `<invoice-ID>` por el `id` de la nota de crédito que neces
         "total_sin_impuestos": "150.00",
         "impuestos": [
             {
-                "codigo": 2,
+                "codigo": "2",
                 "codigo_porcentaje": "2",
                 "base_imponible": "150.00",
                 "valor": "18.00"

--- a/source/includes/debit-notes.md
+++ b/source/includes/debit-notes.md
@@ -685,7 +685,7 @@ Reemplaza en la ruta `<id-notadebito>` por el `id` de la nota de débito que nec
         "propina": "0.00",
         "impuestos": [
             {
-                "codigo": 2,
+                "codigo": "2",
                 "codigo_porcentaje": "2",
                 "base_imponible": "150.00",
                 "valor": "18.00"

--- a/source/includes/invoices.md
+++ b/source/includes/invoices.md
@@ -1758,7 +1758,7 @@ Reemplaza en la ruta `<invoice-ID>` por el `id` de la factura que necesitas cons
         "propina": "0.00",
         "impuestos": [
             {
-                "codigo": 2,
+                "codigo": "2",
                 "codigo_porcentaje": "2",
                 "base_imponible": "150.00",
                 "valor": "18.00"

--- a/source/includes/next/es/ec/sales/invoices.md
+++ b/source/includes/next/es/ec/sales/invoices.md
@@ -413,11 +413,11 @@ issue_to<p class="dt-data-type">string</p> | Lista facturas a partir de esta fec
 sequence_from<p class="dt-data-type">string</p> | Lista facturas a partir de esta secuencia.
 sequence_to<p class="dt-data-type">string</p> | Lista facturas hasta esta secuencia.
 supplier_locations_codes<p class="dt-data-type">array</p> | Listado de códigos de establecimiento separados por coma, ej: 001,004,005
-supplier_locations_points_of_sale<p class="dt-data-type">array</p> | Listado de códigos de punto de emisión separados por coma, ej: 001,004,005
+supplier_location_points_of_sale_codes<p class="dt-data-type">array</p> | Listado de códigos de punto de emisión separados por coma, ej: 001,004,005
 select_keys<p class="dt-data-type">string</p> | Listado de nombres de atributos de la factura separados por coma que se quisieran obtener en la respuesta. Si no se especifica la respuesta incluye el objeto completo. Ej: number,issue_date,items
 page_size<p class="dt-data-type">integer</p> | Define la cantidad de items por página. Por defecto retorna 30 items por página
 order_by <p class="dt-data-type">string</p> | Listado de nombres de atributos de la factura por los que quisieras ordenar el listado, por ejemplo: "sequence". Para ordenar de forma descendente utiliza un guión "-" como prefijo al nombre del atributo, así: "-sequence"
-environment<p class="dt-data-type">integer</p> | Lista facturas dependiento del ambiente
+environment<p class="dt-data-type">string</p> | Lista facturas dependiento del ambiente. Se usa "live" o 2 para facturas de producción o "test" o 1 para facturas de prueba
 
 
 #### Respuesta

--- a/source/includes/retentions.md
+++ b/source/includes/retentions.md
@@ -40,7 +40,7 @@ curl -v https://link.datil.co/retentions/issue \
   "items":[
     {
       "base_imponible": 4226.4,
-      "codigo": 1,
+      "codigo": "1",
       "codigo_porcentaje": "312",
       "fecha_emision_documento_sustento": "2015-12-04T00:00:00-05:19",
       "numero_documento_sustento": "011-007-000000251",
@@ -88,7 +88,7 @@ retencion = {
   "items":[
     {
       "base_imponible": 4226.4,
-      "codigo": 1,
+      "codigo": "1",
       "codigo_porcentaje": "312",
       "fecha_emision_documento_sustento": "2015-12-04T00:00:00-05:19",
       "numero_documento_sustento": "011-007-000000251",
@@ -255,7 +255,7 @@ Remember — a happy kitten is an authenticated kitten!
   "items":[
     {
       "base_imponible": 4226.4,
-      "codigo": 1,
+      "codigo": "1",
       "codigo_porcentaje": "312",
       "fecha_emision_documento_sustento": "2015-12-04T00:00:00-05:19",
       "numero_documento_sustento": "011-007-000000251",
@@ -532,7 +532,7 @@ Reemplaza en la ruta `<receipt-id>` por el `id` de la retención que necesitas c
     "items":[
       {
         "base_imponible": 4226.4,
-        "codigo": 1,
+        "codigo": "1",
         "codigo_porcentaje": "312",
         "fecha_emision_documento_sustento": "2015-12-04T00:00:00-05:19",
         "numero_documento_sustento": "011007000000251",

--- a/source/includes/waybills.md
+++ b/source/includes/waybills.md
@@ -674,7 +674,7 @@ Reemplaza en la ruta `<receipt-id>` por el `id` de la guía de remisión que nec
         "propina": "0.00",
         "impuestos": [
             {
-                "codigo": 2,
+                "codigo": "2",
                 "codigo_porcentaje": "2",
                 "base_imponible": "150.00",
                 "valor": "18.00"


### PR DESCRIPTION
- Adds the correct values to filter invoices by environment
- Fixes "supplier_locations_points_of_sale" to "supplier_location_point_of_sales_codes" parameter in list invoices

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->