### PR TITLE
Add missing field for invoice credit

### DIFF
--- a/source/includes/common.md
+++ b/source/includes/common.md
@@ -515,7 +515,8 @@ Otros | otros | Otros con utilización del sistema financiero | 20
 Endoso de títulos | endoso_titulos | Endoso de títulos | 21
 
 Debido a que el Servicio de Rentas Internas exige incluir información del pago,
-las facturas a crédito se enviarán al SRI con forma de pago "Otros con utilización del sistema financiero".
+las facturas a crédito se enviarán al SRI con forma de pago "Otros con utilización del sistema financiero",
+a menos que se envíe otro código de tipo de pago.
 
 ## Tipo de proveedor
 

--- a/source/includes/invoices.md
+++ b/source/includes/invoices.md
@@ -457,6 +457,7 @@ Parámetro           | Tipo    | Descripción
 ------------------- | ------- | ----------
 fecha_vencimiento   | string  | Fecha de vencimiento en formato AAAA-MM-DD, definido en el estándar [ISO8601](http://tools.ietf.org/html/rfc3339#section-5.6). __Requerido__
 monto               | float   | Monto otorgado de crédito. __Requerido__
+medio               | string  | Ver [tabla](#tipos-de-forma-de-pago) de tipos de forma de pago
 
 #### Compensación solidaria
 
@@ -510,7 +511,8 @@ otros_gastos_transporte   | float  | Total de otros gastos de transporte.
 
 <aside class="notice">
 La información de crédito será enviada como forma de pago al Servicio de
-Rentas Internas (SRI) con el código 01, Sin utilización del sistema financiero.
+Rentas Internas (SRI) con el código 20, Con utilización del sistema financiero, en
+caso que no se especifíque un código de tipo de pago en el crédito de la factura
 </aside>
 
 ### Respuesta


### PR DESCRIPTION
- Add missing optional field `medio` in invoice credit
- Fix wrong message about payment method used for credit invoices when no method was specified. It previously indicated the payment method used was `Sin utilización del sistema financiero` when it actually was `Otros con utilización del sistema financiero`
<img width="603" alt="image" src="https://github.com/user-attachments/assets/9ec7b3ab-c11d-4d72-9e9c-d92e8cb61e55">
<img width="603" alt="image" src="https://github.com/user-attachments/assets/f35efb1d-f02f-4a69-84c1-da9cf88cde4d">
<img width="594" alt="image" src="https://github.com/user-attachments/assets/6d7c61e7-a155-4cac-8d22-f108c3d9ce32">
